### PR TITLE
Remove explicit targeting of the hosted queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-agents:
-  queue: "hosted"
-
 steps:
   - label: ":shell: Tests"
     plugins:


### PR DESCRIPTION
Same premise as [this](https://github.com/buildkite-plugins/vault-secrets-buildkite-plugin/pull/57) - queue is now defaulted